### PR TITLE
Bug fix: Undo reverse stream order

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -30,7 +30,7 @@ router.get("/replay",async (req, res)=>{
 
     let data = await fetch("https://api.sibr.dev/chronicler/v1/stream/updates?limit=100&after="+fromDate.toISOString()).then(async data=>data.json());
 
-    data = data.data.map(data=>data.data).reverse();
+    data = data.data.map(data=>data.data)
 
     console.log("Starting stream");
     

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -11,7 +11,7 @@ const fetch = require("node-fetch");
  * @summary Begin a replay from a time, to a time
  * @param {ISO-Timestamp} from - The start timestamp of the updates to replay.
  * @param {integer} interval - How long to take between each message in ms. Default: 3000 
- * @returns {text/event-stream} 200 - A series of server sent events, When updates end, the server will send an event with the data `close` to indicate the event stream should be closed. No more events will be sent after this.
+ * @returns {text/event-stream} 200 - A series of server sent events, When updates end, the server will send an event with the data `end` to indicate the event stream should be closed. No more events will be sent after this.
  */
 router.get("/replay",async (req, res)=>{
     if(!req.query.from) {


### PR DESCRIPTION
### Bug

I noticed that the replay API was streaming the requested events in reverse-chronological order, starting with the 100th entry and working down to the first.

I checked against 2 different timestamps:

#### https://api.sibr.dev/replay/v1/replay?from=2020-08-30T01:00:08.17Z
- This is [S4 D112](https://reblase.sibr.dev/game/628a2ddb-f608-411b-8d2e-2768cd36d58b) (Tigers vs Millenials)
- Checking against the `lastUpdate` field (for the only game in the `schedule`), the events are streamed as follows:
  1. Mclaughlin Scorlper batting for the tigers.
  2. Top of 4, Hades Tigers batting.
  3. Pelenlope Mathews strikes out looking.
  4. ...
  5. Fish Summer hit a flyout to Penelope Mathews.
  5. Foul ball. 0-1
  6. Fish summer batting for the Tigers.

So it looks like it's streaming backwards from ~top of the 4th, to the first pitch of the game.

#### https://api.sibr.dev/replay/v1/replay?from=2021-03-06T23:00:00.907735Z
- This is [S12 D116](https://reblase.sibr.dev/game/0f19d78d-c27d-4146-863d-b55e6dae1679) (Garages vs Tigers)
- Checking against the `lastUpdate` field, the events streamed as follows:
  1. Paula Mason steals third base!
  2. Strike, swinging. 0-1. (x3)
  3. Usurper Violet batting for the Tigers (x3).
  4. Aldon Cashmoney strikes out looking (x3)
  5. ...
  6. Oliver Notarabot batting for the garages. (x3)
  6. Top of 1, Seattle Garages batting. (x3)
  6. Play ball! (x3)

Cause of all the dupes, this one works its way backward from the bottom of the 1st to the start of the game.

### Fixes

- Removed the bit that was reversing the data that comes from Chronicler. I couldn't find why this data was being reversed, since it doesn't seem like this route in Chronicler changed. ¯\_(ヅ)_/¯
- The Chronicler API uses `count` to limit results, fixed the query to match this. Also exposed this as an optional query parameter for replay, leaving the default as 100.
- Updated the doc to say that the last message sent is `end` (instead of `closed`).